### PR TITLE
Fix ValueError: Output Array is readonly

### DIFF
--- a/pylinac/core/image.py
+++ b/pylinac/core/image.py
@@ -666,7 +666,7 @@ class DicomImage(BaseImage):
         if dtype is not None:
             self.array = ds.pixel_array.astype(dtype)
         else:
-            self.array = ds.pixel_array
+            self.array = ds.pixel_array.copy()
         # convert values to proper HU: real_values = slope * raw + intercept
         if self.metadata.SOPClassUID.name == 'CT Image Storage':
             self.array = int(self.metadata.RescaleSlope)*self.array + int(self.metadata.RescaleIntercept)


### PR DESCRIPTION
The dicom image array is readonly and therefore the self.array -= min_val here https://github.com/jmadamesila/TBCCpylinac/edit/master/pylinac/core/image.py#L465) throws a ValueError.  The reason the Pylinac demo file does not trigger this bug is because it gets inverted which reassigns the array (here: https://github.com/jmadamesila/TBCCpylinac/edit/master/pylinac/core/image.py#L383) and hence makes it writeable.  For images which don't get inverted pylinac tries to write to the dicom dataset causing the ValueError.